### PR TITLE
Fix icon and skip deplaylistify on alt keypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 This is a simple browser extension to deal with the recent YouTube change causing any music videos to be opened as playlists instead of a single video.
 Simply install this extension into your browser and refresh your page - it will automatically clean up your URLs!
+
+Attributions:
+
+Icon:
+https://www.flaticon.com/free-icon/middle-finger_12179538?term=middle+finger&related_id=12179538

--- a/deplaylistify.js
+++ b/deplaylistify.js
@@ -1,28 +1,30 @@
 let previousUrl = null //used for when the webpage injects url changes instead of reloading, thanks YT
 
-//Add a listener for ALT keypress and toggle a bool.
+//Add a listener for ALT keypress and toggle a bool after 5 seconds.
 function keyreleaseHandler(event) {
-    if (event.altKey == true) {
+    if (event.key === "Alt") {
         console.log("deplaylistify: Alt key released!");
-        browser.storage.local.set({ bypass_clean: "true" });
+        localStorage.setItem("skip_checking", "true")
+        setTimeout(() => {
+            localStorage.setItem("skip_checking", "false")
+        }, 5000);
     };
 };
-
-//function keypressHandler(event) {
-//    if (event.altKey == true) {
-//        console.log("deplaylistify: Alt key pressed!");
-//        browser.storage.local.set({ bypass_clean: "true" });
-//    };
-//};
-
-
-//document.addEventListener("keydown", keypressHandler);
 
 document.addEventListener("keyup", keyreleaseHandler);
 
 function cleanURL() {
     let current_url = window.location.href;
-    if (window.location.href == previousUrl) return //skip check if URL hasn't changed
+
+    if (localStorage.getItem("skip_checking") === "true") {
+        console.log("deplaylistify bypassed!!")
+        // update the current URL otherwise the playlist URL  will get cleaned
+        // and reloaded when this is cleared and checkURL reruns on the page
+        previousUrl = current_url.toString()
+        return
+    }
+    //skip check if URL hasn't changed or if we've bypassed the url cleaning
+    if (window.location.href === previousUrl) return
 
     if (previousUrl == null) {
         console.log(`deplaylistify: loading page, URL is ${current_url}`);
@@ -47,6 +49,3 @@ const config = { subtree: true, childList: true };
 
 // start observing change
 UrlObserver.observe(document, config);
-
-//TODO: add a listener for keypress and save to local storage as a bool.
-// so we can avoid cleaning when needed.

--- a/manifest.json
+++ b/manifest.json
@@ -8,8 +8,8 @@
     ],
     "description": "Prevent Youtube from opening videos as playlists",
     "icons": {
-        "48": "icons/icon.png",
-        "96": "icons/icon.png"
+        "48": "icons/icon.svg",
+        "96": "icons/icon.svg"
     },
     "content_scripts": [
         {


### PR DESCRIPTION
Fix broken icon due to incorrect filename 'icons/icon.png' in manifest.json

Bypass deplaylistifying for 5s on alt key release by checking for the
string variable skip_checking to be 'true' in local storage. This lets
us bypass deplaylistifying across multiple tabs running YouTube and is a
comfortable amount of time for users to click on links after activating
the bypass.